### PR TITLE
Fix release workflow after merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR build
             echo "tag=pr-${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=publish,validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           else
             # Main branch build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           else
             # Main branch build
             echo "tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=publish,validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Previously, main branch builds used `--skip=publish,validate` which prevented Docker images from being pushed. Changed to `--skip=validate` to allow Docker image publishing while still skipping GitHub releases for non-tag builds.

This ensures that commits to main will publish Docker images with tags like `sha-<commit>-amd64` and `sha-<commit>-arm64` as expected.