### PR TITLE
Upgrade project to Go 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.25'
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pixelfactoryio/crashlooper
 
-go 1.18
+go 1.25
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137


### PR DESCRIPTION
Upgrades the project from Go 1.18 to Go 1.25, the latest stable version.

Changes:
- Updated go.mod to specify Go 1.25
- Updated GitHub Actions workflow to use Go 1.25

This upgrade brings 7 major version improvements with enhanced performance, security fixes, and new language features.