### PR TITLE
Add unit tests with mocking support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run go fmt
+        run: |
+          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+            echo "The following files need to be formatted:"
+            gofmt -s -l .
+            exit 1
+          fi
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Display coverage
+        run: go tool cover -func=coverage.out
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.out
+          flags: unittests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitConfig(t *testing.T) {
+	// Reset viper for clean state
+	viper.Reset()
+
+	initConfig()
+
+	// Verify viper is configured correctly
+	require.NotEmpty(t, viper.Get("revision"))
+}
+
+func TestInitConfig_EnvironmentVariables(t *testing.T) {
+	// Reset viper for clean state
+	viper.Reset()
+
+	// Set environment variables
+	os.Setenv("CRASHLOOPER_LOG_LEVEL", "debug")
+	os.Setenv("CRASHLOOPER_PORT", "8080")
+	defer os.Unsetenv("CRASHLOOPER_LOG_LEVEL")
+	defer os.Unsetenv("CRASHLOOPER_PORT")
+
+	initConfig()
+
+	// Verify environment variables are picked up
+	require.Equal(t, "debug", viper.GetString("log-level"))
+	require.Equal(t, "8080", viper.GetString("port"))
+}
+
+func TestNewRootCmd(t *testing.T) {
+	// Reset viper for clean state
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "crashlooper", cmd.Use)
+	require.True(t, cmd.SilenceUsage)
+	require.True(t, cmd.SilenceErrors)
+	require.NotNil(t, cmd.RunE)
+}
+
+func TestNewRootCmd_Flags(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		flagName     string
+		expectedType string
+	}{
+		{
+			name:         "log-level flag exists",
+			flagName:     "log-level",
+			expectedType: "string",
+		},
+		{
+			name:         "port flag exists",
+			flagName:     "port",
+			expectedType: "string",
+		},
+		{
+			name:         "memory-target flag exists",
+			flagName:     "memory-target",
+			expectedType: "string",
+		},
+		{
+			name:         "memory-increment flag exists",
+			flagName:     "memory-increment",
+			expectedType: "string",
+		},
+		{
+			name:         "memory-increment-interval flag exists",
+			flagName:     "memory-increment-interval",
+			expectedType: "duration",
+		},
+		{
+			name:         "crash-after flag exists",
+			flagName:     "crash-after",
+			expectedType: "duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := cmd.PersistentFlags().Lookup(tt.flagName)
+			require.NotNil(t, flag, "flag %s should exist", tt.flagName)
+			require.Equal(t, tt.expectedType, flag.Value.Type())
+		})
+	}
+}
+
+func TestNewRootCmd_DefaultValues(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	// Check default values
+	logLevelFlag := cmd.PersistentFlags().Lookup("log-level")
+	require.Equal(t, "info", logLevelFlag.DefValue)
+
+	portFlag := cmd.PersistentFlags().Lookup("port")
+	require.Equal(t, "3000", portFlag.DefValue)
+
+	crashAfterFlag := cmd.PersistentFlags().Lookup("crash-after")
+	require.Equal(t, "0s", crashAfterFlag.DefValue)
+
+	memIncrementIntervalFlag := cmd.PersistentFlags().Lookup("memory-increment-interval")
+	require.Equal(t, "1s", memIncrementIntervalFlag.DefValue)
+}
+
+func TestNewRootCmd_FlagBinding(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	// Set flags
+	cmd.PersistentFlags().Set("log-level", "debug")
+	cmd.PersistentFlags().Set("port", "8080")
+	cmd.PersistentFlags().Set("crash-after", "5s")
+
+	// Initialize config to bind flags
+	initConfig()
+
+	// Verify viper has the values
+	require.Equal(t, "debug", viper.GetString("log-level"))
+	require.Equal(t, "8080", viper.GetString("port"))
+	require.Equal(t, 5*time.Second, viper.GetDuration("crash-after"))
+}
+
+func TestNewRootCmd_MemoryFlags(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	// Set memory flags
+	cmd.PersistentFlags().Set("memory-target", "100MB")
+	cmd.PersistentFlags().Set("memory-increment", "10MB")
+	cmd.PersistentFlags().Set("memory-increment-interval", "500ms")
+
+	initConfig()
+
+	require.Equal(t, "100MB", viper.GetString("memory-target"))
+	require.Equal(t, "10MB", viper.GetString("memory-increment"))
+	require.Equal(t, 500*time.Millisecond, viper.GetDuration("memory-increment-interval"))
+}
+
+func TestExecute_CreatesCommand(t *testing.T) {
+	viper.Reset()
+
+	// We can't fully test Execute() as it would start the server
+	// But we can verify the command creation doesn't error
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+}
+
+func TestNewRootCmd_ViperBinding(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	// Set flags and ensure viper binding works
+	flags := []string{
+		"log-level",
+		"port",
+		"memory-target",
+		"memory-increment",
+		"memory-increment-interval",
+		"crash-after",
+	}
+
+	for _, flagName := range flags {
+		flag := cmd.PersistentFlags().Lookup(flagName)
+		require.NotNil(t, flag, "flag %s should exist", flagName)
+	}
+}
+
+func TestNewRootCmd_FlagTypes(t *testing.T) {
+	viper.Reset()
+
+	cmd, err := NewRootCmd()
+	require.NoError(t, err)
+
+	// Test string flags
+	stringFlags := []string{"log-level", "port", "memory-target", "memory-increment"}
+	for _, flagName := range stringFlags {
+		flag := cmd.PersistentFlags().Lookup(flagName)
+		require.NotNil(t, flag)
+		require.Equal(t, "string", flag.Value.Type())
+	}
+
+	// Test duration flags
+	durationFlags := []string{"memory-increment-interval", "crash-after"}
+	for _, flagName := range durationFlags {
+		flag := cmd.PersistentFlags().Lookup(flagName)
+		require.NotNil(t, flag)
+		require.Equal(t, "duration", flag.Value.Type())
+	}
+}
+
+func TestInitConfig_RevisionSet(t *testing.T) {
+	viper.Reset()
+
+	initConfig()
+
+	// Verify revision is set (even if empty)
+	revision := viper.Get("revision")
+	require.NotNil(t, revision)
+}
+
+func TestInitConfig_EnvPrefix(t *testing.T) {
+	viper.Reset()
+
+	// Set environment variable with CRASHLOOPER prefix
+	os.Setenv("CRASHLOOPER_TEST_VALUE", "test123")
+	defer os.Unsetenv("CRASHLOOPER_TEST_VALUE")
+
+	initConfig()
+
+	// Verify the environment variable can be read
+	require.Equal(t, "test123", viper.GetString("test-value"))
+}
+
+func TestInitConfig_EnvKeyReplacer(t *testing.T) {
+	viper.Reset()
+
+	// Test that hyphen to underscore replacement works
+	os.Setenv("CRASHLOOPER_LOG_LEVEL", "debug")
+	defer os.Unsetenv("CRASHLOOPER_LOG_LEVEL")
+
+	initConfig()
+
+	// Verify the value is accessible with hyphenated key
+	require.Equal(t, "debug", viper.GetString("log-level"))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pixelfactoryio/crashlooper
 
-go 1.24
+go 1.25
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pixelfactoryio/crashlooper
 
-go 1.25
+go 1.24
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
@@ -8,12 +8,14 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
+	github.com/stretchr/testify v1.7.1
 	go.pixelfactory.io/pkg/observability/log v1.2.0
 	go.pixelfactory.io/pkg/server v0.1.0
 	go.pixelfactory.io/pkg/version v0.1.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -24,6 +26,7 @@ require (
 	github.com/mssola/user_agent v0.5.3 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHj
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
@@ -139,6 +140,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -197,9 +199,11 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
@@ -250,6 +254,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/internal/api/handlers/default_test.go
+++ b/internal/api/handlers/default_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultHandler(t *testing.T) {
+	handler := NewDefaultHandler()
+	require.NotNil(t, handler)
+	require.IsType(t, &defaultHandler{}, handler)
+}
+
+func TestDefaultHandler_ServeHTTP(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "successful GET request",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusOK,
+			expectedBody:   "CrashLooper",
+		},
+		{
+			name:           "successful POST request",
+			method:         http.MethodPost,
+			expectedStatus: http.StatusOK,
+			expectedBody:   "CrashLooper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler := NewDefaultHandler()
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+			require.Contains(t, rec.Body.String(), tt.expectedBody)
+			require.Contains(t, rec.Body.String(), "<title>CrashLooper</title>")
+			require.Contains(t, rec.Body.String(), "<a href='/shutdown'>Shutdown</a>")
+		})
+	}
+}
+
+func TestDefaultHandler_ServeHTTP_ResponseFormat(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler := NewDefaultHandler()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	// Verify HTML structure
+	require.Contains(t, body, "<html>")
+	require.Contains(t, body, "<head>")
+	require.Contains(t, body, "<body>")
+	require.Contains(t, body, "<h1>CrashLooper</h1>")
+	require.Contains(t, body, "</html>")
+}

--- a/internal/api/handlers/status_test.go
+++ b/internal/api/handlers/status_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatusHandler(t *testing.T) {
+	handler := NewStatusHandler()
+	require.NotNil(t, handler)
+	require.IsType(t, &statusHandler{}, handler)
+}
+
+func TestStatusHandler_ServeHTTP(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		expectedStatus int
+	}{
+		{
+			name:           "successful GET request",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "successful POST request",
+			method:         http.MethodPost,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "successful PUT request",
+			method:         http.MethodPut,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/checks/health", nil)
+			rec := httptest.NewRecorder()
+
+			handler := NewStatusHandler()
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+			require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+			var response status
+			err := json.NewDecoder(rec.Body).Decode(&response)
+			require.NoError(t, err)
+			require.Equal(t, "OK", response.Status)
+		})
+	}
+}
+
+func TestStatusHandler_ServeHTTP_JSONFormat(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/checks/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler := NewStatusHandler()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify Content-Type header is set correctly
+	contentType := rec.Header().Get("Content-Type")
+	require.Equal(t, "application/json", contentType)
+
+	// Verify JSON structure
+	var response map[string]interface{}
+	err := json.NewDecoder(rec.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Contains(t, response, "status")
+	require.Equal(t, "OK", response["status"])
+}
+
+func TestStatusHandler_ServeHTTP_ResponseStruct(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/checks/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler := NewStatusHandler()
+	handler.ServeHTTP(rec, req)
+
+	var response status
+	err := json.NewDecoder(rec.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Equal(t, "OK", response.Status)
+}

--- a/internal/api/middlewares/logger_test.go
+++ b/internal/api/middlewares/logger_test.go
@@ -1,0 +1,254 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.pixelfactory.io/pkg/observability/log"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestWrapResponseWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapped := wrapResponseWriter(rec)
+
+	require.NotNil(t, wrapped)
+	require.Equal(t, rec, wrapped.ResponseWriter)
+	require.Equal(t, 0, wrapped.status)
+	require.False(t, wrapped.wroteHeader)
+}
+
+func TestResponseWriter_WriteHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		expectedStatus int
+	}{
+		{
+			name:           "write 200 status",
+			statusCode:     http.StatusOK,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "write 404 status",
+			statusCode:     http.StatusNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "write 500 status",
+			statusCode:     http.StatusInternalServerError,
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			wrapped := wrapResponseWriter(rec)
+
+			wrapped.WriteHeader(tt.statusCode)
+
+			require.Equal(t, tt.expectedStatus, wrapped.Status())
+			require.True(t, wrapped.wroteHeader)
+			require.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestResponseWriter_WriteHeader_MultipleCallsIgnored(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapped := wrapResponseWriter(rec)
+
+	// First call should set the status
+	wrapped.WriteHeader(http.StatusOK)
+	require.Equal(t, http.StatusOK, wrapped.Status())
+	require.True(t, wrapped.wroteHeader)
+
+	// Second call should be ignored
+	wrapped.WriteHeader(http.StatusInternalServerError)
+	require.Equal(t, http.StatusOK, wrapped.Status())
+	require.True(t, wrapped.wroteHeader)
+}
+
+func TestResponseWriter_Status_BeforeWriteHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wrapped := wrapResponseWriter(rec)
+
+	// Status should be 0 before WriteHeader is called
+	require.Equal(t, 0, wrapped.Status())
+}
+
+func TestLogging_Middleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		handlerFunc    http.HandlerFunc
+		expectedStatus int
+	}{
+		{
+			name: "successful request",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("success"))
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "not found request",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("not found"))
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name: "internal server error",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("error"))
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.WithLevel("debug"))
+			middleware := Logging(logger)
+
+			handler := middleware(tt.handlerFunc)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestLogging_Middleware_WithPanic(t *testing.T) {
+	logger := log.New(log.WithLevel("debug"))
+	middleware := Logging(logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	// The middleware should catch the panic and return 500
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestLogging_Middleware_LogsRequestDetails(t *testing.T) {
+	logger := log.New(log.WithLevel("debug"))
+	middleware := Logging(logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test-path?query=param", nil)
+	req.Header.Set("User-Agent", "test-agent")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestLogging_Middleware_CapturesStatusCode(t *testing.T) {
+	statusCodes := []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusNoContent,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+
+	for _, code := range statusCodes {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			logger := log.New(log.WithLevel("debug"))
+			middleware := Logging(logger)
+
+			handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, code, rec.Code)
+		})
+	}
+}
+
+// mockLogger is a simple mock implementation of log.Logger for testing
+type mockLogger struct {
+	debugCalled bool
+	errorCalled bool
+	lastMessage string
+	lastFields  []zapcore.Field
+}
+
+func (m *mockLogger) Debug(msg string, fields ...zapcore.Field) {
+	m.debugCalled = true
+	m.lastMessage = msg
+	m.lastFields = fields
+}
+
+func (m *mockLogger) Error(msg string, fields ...zapcore.Field) {
+	m.errorCalled = true
+	m.lastMessage = msg
+	m.lastFields = fields
+}
+
+func (m *mockLogger) Info(msg string, fields ...zapcore.Field) {}
+func (m *mockLogger) Warn(msg string, fields ...zapcore.Field) {}
+func (m *mockLogger) Fatal(msg string, fields ...zapcore.Field) {}
+func (m *mockLogger) Panic(msg string, fields ...zapcore.Field) {}
+
+func TestLogging_Middleware_CallsLogger(t *testing.T) {
+	mockLog := &mockLogger{}
+	middleware := Logging(mockLog)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, mockLog.debugCalled)
+	require.Equal(t, "Request", mockLog.lastMessage)
+}
+
+func TestLogging_Middleware_PanicCallsLogger(t *testing.T) {
+	mockLog := &mockLogger{}
+	middleware := Logging(mockLog)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, mockLog.errorCalled)
+	require.Equal(t, "Internal Server Error", mockLog.lastMessage)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/internal/api/middlewares/logger_test.go
+++ b/internal/api/middlewares/logger_test.go
@@ -213,8 +213,8 @@ func (m *mockLogger) Error(msg string, fields ...zapcore.Field) {
 	m.lastFields = fields
 }
 
-func (m *mockLogger) Info(msg string, fields ...zapcore.Field) {}
-func (m *mockLogger) Warn(msg string, fields ...zapcore.Field) {}
+func (m *mockLogger) Info(msg string, fields ...zapcore.Field)  {}
+func (m *mockLogger) Warn(msg string, fields ...zapcore.Field)  {}
 func (m *mockLogger) Fatal(msg string, fields ...zapcore.Field) {}
 func (m *mockLogger) Panic(msg string, fields ...zapcore.Field) {}
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.pixelfactory.io/pkg/observability/log"
+)
+
+func TestNewRouter(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	require.NotNil(t, router)
+}
+
+func TestNewRouter_HealthEndpoint(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		checkJSON      bool
+	}{
+		{
+			name:           "exact health check path",
+			path:           "/checks/health",
+			expectedStatus: http.StatusOK,
+			checkJSON:      true,
+		},
+		{
+			name:           "health check with trailing slash",
+			path:           "/checks/health/",
+			expectedStatus: http.StatusOK,
+			checkJSON:      true,
+		},
+		{
+			name:           "health check with extra path",
+			path:           "/checks/health/extra",
+			expectedStatus: http.StatusOK,
+			checkJSON:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+
+			if tt.checkJSON {
+				contentType := rec.Header().Get("Content-Type")
+				require.Equal(t, "application/json", contentType)
+				require.Contains(t, rec.Body.String(), "status")
+			}
+		})
+	}
+}
+
+func TestNewRouter_DefaultEndpoint(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "root path",
+			path:           "/",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "CrashLooper",
+		},
+		{
+			name:           "random path",
+			path:           "/random",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "CrashLooper",
+		},
+		{
+			name:           "shutdown path",
+			path:           "/shutdown",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "CrashLooper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+			require.Contains(t, rec.Body.String(), tt.expectedBody)
+		})
+	}
+}
+
+func TestNewRouter_HealthCheckPriority(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	// Health check should return JSON
+	req := httptest.NewRequest(http.MethodGet, "/checks/health", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.Contains(t, rec.Body.String(), `"status"`)
+	require.NotContains(t, rec.Body.String(), "<html>")
+}
+
+func TestNewRouter_DefaultHandlerFallback(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	// Any path not matching /checks/health should return HTML
+	req := httptest.NewRequest(http.MethodGet, "/any-other-path", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "<html>")
+	require.Contains(t, rec.Body.String(), "CrashLooper")
+}
+
+func TestNewRouter_DifferentHTTPMethods(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	router := NewRouter(logger)
+
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	}
+
+	for _, method := range methods {
+		t.Run(method+"_health", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/checks/health", nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+		})
+
+		t.Run(method+"_default", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/", nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+func TestNewRouter_MiddlewareApplied(t *testing.T) {
+	logger := log.New(log.WithLevel("debug"))
+	router := NewRouter(logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("User-Agent", "test-agent")
+	rec := httptest.NewRecorder()
+
+	// Make request through router which should have logging middleware
+	router.ServeHTTP(rec, req)
+
+	// Verify the request was successful
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/services/crash/crash_test.go
+++ b/internal/services/crash/crash_test.go
@@ -1,0 +1,119 @@
+package crash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.pixelfactory.io/pkg/observability/log"
+)
+
+func TestNew(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	after := 5 * time.Second
+
+	svc := New(logger, after)
+
+	require.NotNil(t, svc)
+	require.Equal(t, logger, svc.logger)
+	require.Equal(t, after, svc.after)
+}
+
+func TestNew_WithDifferentDurations(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+	}{
+		{
+			name:     "1 second",
+			duration: 1 * time.Second,
+		},
+		{
+			name:     "5 seconds",
+			duration: 5 * time.Second,
+		},
+		{
+			name:     "1 minute",
+			duration: 1 * time.Minute,
+		},
+		{
+			name:     "10 milliseconds",
+			duration: 10 * time.Millisecond,
+		},
+		{
+			name:     "0 duration",
+			duration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.WithLevel("info"))
+			svc := New(logger, tt.duration)
+
+			require.NotNil(t, svc)
+			require.Equal(t, tt.duration, svc.after)
+		})
+	}
+}
+
+func TestService_Fields(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	after := 10 * time.Second
+
+	svc := New(logger, after)
+
+	require.NotNil(t, svc.logger)
+	require.Equal(t, after, svc.after)
+}
+
+// Note: We cannot fully test Start() method as it calls os.Exit(1) which would terminate the test
+// In a real-world scenario, you might want to refactor the code to make os.Exit injectable
+// or use an interface to allow mocking the exit behavior for testing purposes.
+
+func TestService_Start_TimerCreated(t *testing.T) {
+	// This test verifies the service can be created and would start a timer
+	// We use a very long duration to avoid the actual crash during the test
+	logger := log.New(log.WithLevel("info"))
+	after := 1 * time.Hour
+
+	svc := New(logger, after)
+	require.NotNil(t, svc)
+
+	// We can't fully test Start() without it blocking or calling os.Exit
+	// In production code, you might want to refactor to allow dependency injection
+	// of the exit function for testing purposes
+}
+
+// TestService_Integration tests that the service can be created and would work correctly
+// without actually triggering the crash
+func TestService_Integration(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+	}{
+		{
+			name:     "short duration",
+			duration: 100 * time.Millisecond,
+		},
+		{
+			name:     "medium duration",
+			duration: 1 * time.Second,
+		},
+		{
+			name:     "long duration",
+			duration: 1 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := New(logger, tt.duration)
+			require.NotNil(t, svc)
+			require.Equal(t, tt.duration, svc.after)
+			require.NotNil(t, svc.logger)
+		})
+	}
+}

--- a/internal/services/memory/memory_test.go
+++ b/internal/services/memory/memory_test.go
@@ -1,0 +1,209 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/stretchr/testify/require"
+	"go.pixelfactory.io/pkg/observability/log"
+)
+
+func TestNew(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	memTarget := 100 * units.MiB
+	memIncrement := 10 * units.MiB
+	memIncrementInterval := 1 * time.Second
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	require.NotNil(t, svc)
+	require.Equal(t, logger, svc.logger)
+	require.Equal(t, memTarget, svc.memTarget)
+	require.Equal(t, memIncrement, svc.memIncrement)
+	require.Equal(t, memIncrementInterval, svc.memIncrementInterval)
+	require.NotNil(t, svc.reader)
+}
+
+func TestNew_CalculatesSteps(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	memTarget := 100 * units.MiB
+	memIncrement := 10 * units.MiB
+	memIncrementInterval := 1 * time.Second
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	expectedSteps := memTarget / memIncrement
+	require.Equal(t, expectedSteps, svc.steps)
+}
+
+func TestNew_WithDifferentSizes(t *testing.T) {
+	tests := []struct {
+		name                 string
+		memTarget            units.Base2Bytes
+		memIncrement         units.Base2Bytes
+		memIncrementInterval time.Duration
+		expectedSteps        units.Base2Bytes
+	}{
+		{
+			name:                 "100MB target, 10MB increment",
+			memTarget:            100 * units.MiB,
+			memIncrement:         10 * units.MiB,
+			memIncrementInterval: 1 * time.Second,
+			expectedSteps:        10,
+		},
+		{
+			name:                 "1GB target, 100MB increment",
+			memTarget:            1 * units.GiB,
+			memIncrement:         100 * units.MiB,
+			memIncrementInterval: 500 * time.Millisecond,
+			expectedSteps:        10,
+		},
+		{
+			name:                 "50MB target, 5MB increment",
+			memTarget:            50 * units.MiB,
+			memIncrement:         5 * units.MiB,
+			memIncrementInterval: 2 * time.Second,
+			expectedSteps:        10,
+		},
+		{
+			name:                 "10MB target, 1MB increment",
+			memTarget:            10 * units.MiB,
+			memIncrement:         1 * units.MiB,
+			memIncrementInterval: 100 * time.Millisecond,
+			expectedSteps:        10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.WithLevel("info"))
+			svc := New(logger, tt.memTarget, tt.memIncrement, tt.memIncrementInterval)
+
+			require.NotNil(t, svc)
+			require.Equal(t, tt.expectedSteps, svc.steps)
+			require.Equal(t, tt.memTarget, svc.memTarget)
+			require.Equal(t, tt.memIncrement, svc.memIncrement)
+			require.Equal(t, tt.memIncrementInterval, svc.memIncrementInterval)
+		})
+	}
+}
+
+func TestNew_CreatesReader(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	memTarget := 10 * units.MiB
+	memIncrement := 1 * units.MiB
+	memIncrementInterval := 100 * time.Millisecond
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	require.NotNil(t, svc.reader)
+
+	// Verify reader can be used
+	buf := make([]byte, 1024)
+	n, err := svc.reader.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 1024, n)
+}
+
+func TestService_Start_ShortRun(t *testing.T) {
+	// Test with very small memory allocation to complete quickly
+	logger := log.New(log.WithLevel("info"))
+	memTarget := 10 * units.KiB
+	memIncrement := 1 * units.KiB
+	memIncrementInterval := 1 * time.Millisecond
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+	require.NotNil(t, svc)
+
+	// Run Start in a goroutine with a timeout
+	done := make(chan bool)
+	go func() {
+		svc.Start()
+		done <- true
+	}()
+
+	// Wait for Start to complete or timeout
+	select {
+	case <-done:
+		// Start completed successfully
+		require.True(t, true)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not complete in time")
+	}
+}
+
+func TestService_Start_VerifyIncrement(t *testing.T) {
+	// Test with tiny allocation to verify the increment logic
+	logger := log.New(log.WithLevel("debug"))
+	memTarget := 5 * units.KiB
+	memIncrement := 1 * units.KiB
+	memIncrementInterval := 1 * time.Millisecond
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	// Expected steps should be 5
+	require.Equal(t, units.Base2Bytes(5), svc.steps)
+
+	// Run Start in a goroutine
+	done := make(chan bool)
+	startTime := time.Now()
+
+	go func() {
+		svc.Start()
+		done <- true
+	}()
+
+	// Wait for completion
+	select {
+	case <-done:
+		elapsed := time.Since(startTime)
+		// Should take at least 5 milliseconds (5 steps * 1ms interval)
+		require.GreaterOrEqual(t, elapsed.Milliseconds(), int64(4))
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not complete in time")
+	}
+}
+
+func TestService_Fields(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	memTarget := 100 * units.MiB
+	memIncrement := 10 * units.MiB
+	memIncrementInterval := 1 * time.Second
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	require.NotNil(t, svc.logger)
+	require.Equal(t, memTarget, svc.memTarget)
+	require.Equal(t, memIncrement, svc.memIncrement)
+	require.Equal(t, memIncrementInterval, svc.memIncrementInterval)
+	require.Equal(t, memTarget/memIncrement, svc.steps)
+	require.NotNil(t, svc.reader)
+}
+
+func TestService_Start_WithZeroSteps(t *testing.T) {
+	logger := log.New(log.WithLevel("info"))
+	// This will create 0 steps since increment equals target
+	memTarget := 10 * units.MiB
+	memIncrement := 10 * units.MiB
+	memIncrementInterval := 1 * time.Millisecond
+
+	svc := New(logger, memTarget, memIncrement, memIncrementInterval)
+
+	// Steps should be 1 (target / increment = 1)
+	require.Equal(t, units.Base2Bytes(1), svc.steps)
+
+	done := make(chan bool)
+	go func() {
+		svc.Start()
+		done <- true
+	}()
+
+	// Should complete quickly since there's only 1 step
+	select {
+	case <-done:
+		require.True(t, true)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Start did not complete in time")
+	}
+}


### PR DESCRIPTION
Added unit tests using testify/require for:
- HTTP handlers (default, status)
- Middleware (logging with panic recovery)
- Router configuration and path matching
- Services (crash scheduler, memory manager)
- CLI command configuration and flags

Test coverage includes:
- Handler response validation
- Middleware status code capture
- Multiple HTTP methods
- Configuration binding
- Service initialization
- Error handling paths

Also updated go.mod to include testify and adjusted Go version to 1.24 for compatibility with available toolchain.