### PR TITLE
Fix tagging and release issues

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          CURRENT_TAG=$(svu current || echo "v0.0.0")
-          NEXT_TAG=$(svu next || echo "")
+          # Only consider semantic version tags (v*), ignore pr-* and sha-* tags
+          CURRENT_TAG=$(svu current --pattern="v*" || echo "v0.0.0")
+          NEXT_TAG=$(svu next --pattern="v*" || echo "")
 
           echo "current_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
           echo "next_tag=${NEXT_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,19 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
             echo "args=release --clean" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GORELEASER_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "disable_release=false" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR build - Docker images only, GitHub release disabled in .goreleaser.yml
+            # PR build - Docker images only, GitHub release disabled
             echo "tag=pr-${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
             echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "disable_release=true" >> $GITHUB_OUTPUT
           else
-            # Main branch build - Docker images only, GitHub release disabled in .goreleaser.yml
+            # Main branch build - Docker images only, GitHub release disabled
             echo "tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
             echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "disable_release=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run GoReleaser
@@ -56,3 +59,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.config.outputs.github_token }}
           GORELEASER_CURRENT_TAG: ${{ steps.config.outputs.tag }}
+          GORELEASER_DISABLE_RELEASE: ${{ steps.config.outputs.disable_release }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,19 +32,19 @@ jobs:
         id: config
         run: |
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            # Actual release
+            # Actual release - full release with GitHub release
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
             echo "args=release --clean" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GORELEASER_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR build
+            # PR build - snapshot mode, Docker only, no GitHub release
             echo "tag=pr-${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --snapshot --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           else
-            # Main branch build
+            # Main branch build - snapshot mode, Docker only, no GitHub release
             echo "tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --snapshot --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,14 @@ jobs:
             echo "args=release --clean" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GORELEASER_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR build - Docker only, skip GitHub release publishing
+            # PR build - Docker images only, GitHub release disabled in .goreleaser.yml
             echo "tag=pr-${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=publish --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           else
-            # Main branch build - Docker only, skip GitHub release publishing
+            # Main branch build - Docker images only, GitHub release disabled in .goreleaser.yml
             echo "tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --clean --skip=publish --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,14 @@ jobs:
             echo "args=release --clean" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GORELEASER_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR build - snapshot mode, Docker only, no GitHub release
+            # PR build - Docker only, skip GitHub release publishing
             echo "tag=pr-${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --snapshot --clean --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=publish --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           else
-            # Main branch build - snapshot mode, Docker only, no GitHub release
+            # Main branch build - Docker only, skip GitHub release publishing
             echo "tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "args=release --snapshot --clean --skip=validate" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=publish --skip=validate" >> $GITHUB_OUTPUT
             echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
           fi
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,13 +3,6 @@ version: 2
 env:
   - GO111MODULE=on
 
-release:
-  # Disable GitHub releases for snapshot builds (PRs and main branch)
-  # Only create releases for actual version tags
-  disable: '{{ if .IsSnapshot }}true{{ else }}false{{ end }}'
-  draft: false
-  prerelease: auto
-
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,13 @@ version: 2
 env:
   - GO111MODULE=on
 
+release:
+  # Disable GitHub releases for snapshot builds (PRs and main branch)
+  # Only create releases for actual version tags
+  disable: '{{ if .IsSnapshot }}true{{ else }}false{{ end }}'
+  draft: false
+  prerelease: auto
+
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,8 @@ env:
 
 release:
   # Only create GitHub releases for semantic version tags (v*)
-  # Disable for pr-* and sha-* tags
-  disable: '{{ if hasPrefix .Tag "v" }}false{{ else }}true{{ end }}'
+  # Controlled via GORELEASER_DISABLE_RELEASE environment variable
+  disable: '{{ .Env.GORELEASER_DISABLE_RELEASE }}'
   draft: false
   prerelease: auto
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,13 @@ version: 2
 env:
   - GO111MODULE=on
 
+release:
+  # Only create GitHub releases for semantic version tags (v*)
+  # Disable for pr-* and sha-* tags
+  disable: '{{ if hasPrefix .Tag "v" }}false{{ else }}true{{ end }}'
+  draft: false
+  prerelease: auto
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
- Add --snapshot flag to GoReleaser for PR and main branch builds to prevent GitHub releases
- Add --pattern="v*" to svu commands to ignore non-semantic tags (pr-*, sha-*)
- Configure GoReleaser to disable releases in snapshot mode
- Keep full release behavior only for semantic version tags (v*)

This fixes the following issues:
- svu errors with invalid semantic version tags
- Unwanted GitHub releases for PRs and main branch pushes
- Only semantic version tags will trigger releases now
- Docker images continue to be built and pushed for all workflows