### PR TITLE
Release version 0 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             # Actual release - full release with GitHub release
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
             echo "args=release --clean" >> $GITHUB_OUTPUT
-            echo "github_token=${{ secrets.GORELEASER_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "github_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
             echo "disable_release=false" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR build - Docker images only, GitHub release disabled


### PR DESCRIPTION
The release workflow was failing with "401 Bad credentials" because it was trying to use secrets.GORELEASER_GITHUB_TOKEN which is either not configured or has invalid credentials. Changed to use secrets.GITHUB_TOKEN which is automatically provided by GitHub Actions and has sufficient permissions.