### PR TITLE
Fix missing files in release binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/pixelfactoryio/crashlooper/cmd.Version={{ .Version }}
       - -X go.pixelfactory.io/pkg/version.REVISION={{ .ShortCommit }}
       - -X go.pixelfactory.io/pkg/version.BUILDDATE={{ .CommitDate }}
 checksum:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -18,11 +19,18 @@ import (
 	"github.com/pixelfactoryio/crashlooper/internal/services/memory"
 )
 
+// Version is set by GoReleaser via ldflags
+var Version = "dev"
+
 func initConfig() {
 	viper.Set("revision", version.REVISION)
 	viper.SetEnvPrefix("CRASHLOOPER")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
+}
+
+func getVersionString() string {
+	return fmt.Sprintf("%s (commit: %s, built: %s)", Version, version.REVISION, version.BUILDDATE)
 }
 
 // NewRootCmd create new rootCmd
@@ -33,6 +41,7 @@ func NewRootCmd() (*cobra.Command, error) {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE:          start,
+		Version:       getVersionString(),
 	}
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Server log level")


### PR DESCRIPTION
- Add VERSION to GoReleaser ldflags to inject version into binary
- Add --version flag to CLI using Cobra's built-in support
- Display version, commit hash, and build date when --version is called
- Follows community best practices for Go CLI versioning

This ensures users can easily identify which version of crashlooper they are running, which is helpful for debugging and support.