### PR TITLE
fix: use GORELEASER_GITHUB_TOKEN in auto-tag workflow to trigger releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
       - name: Install svu
         run: |


### PR DESCRIPTION
When using GITHUB_TOKEN to push tags, GitHub prevents triggering other workflows as a security feature. By using GORELEASER_GITHUB_TOKEN (a PAT), tag pushes will now properly trigger the release workflow, creating GitHub releases automatically.